### PR TITLE
Making it possible to use UUID as Identifier.

### DIFF
--- a/CoreDataCodable/FetchableManageObject.swift
+++ b/CoreDataCodable/FetchableManageObject.swift
@@ -12,7 +12,7 @@ import Foundation
 public protocol FetchableManagedObject {
     
     associatedtype FetchableCodingKeys: CodingKey
-    associatedtype Identifier: Decodable & CVarArg
+    associatedtype Identifier: Decodable
     static var identifierKey: FetchableCodingKeys { get }
     
 }
@@ -24,7 +24,7 @@ extension FetchableManagedObject where Self: NSManagedObject {
         let container = try decoder.container(keyedBy: FetchableCodingKeys.self)
         let identifier = try container.decode(Identifier.self, forKey: identifierKey)
         let request = NSFetchRequest<Self>(entityName: String(describing: Self.self))
-        request.predicate = NSPredicate(format: "\(identifierKey.stringValue) = %@", identifier)
+        request.predicate = NSPredicate(format: "%K == %@", argumentArray:[identifierKey.stringValue, identifier])
         return try context.fetch(request).first
     }
     


### PR DESCRIPTION
If you use an attribute of type UUID, you cannot use it as the key to look it up, because UUID does not conform to CVarArg. This will change will make it possible.

At first I tried:
`public typealias Identifier: String` and returning the UUID anyway, but this will make the fetch return nothing because of capitalization of the UUID.